### PR TITLE
document necessary css loaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ module.exports = {
     path: path.resolve(__dirname, 'dist'),
     filename: 'app.js'
   },
+  module: {
+    rules: [{
+      test: /\.css$/,
+      use: ['style-loader', 'css-loader']
+    }]
+  },
   plugins: [
     new MonacoWebpackPlugin()
   ]


### PR DESCRIPTION
Copy the CSS config from the test into the docs, because without this
the same code fails to build.